### PR TITLE
Upgrade mediawiki

### DIFF
--- a/php/RELEASE-NOTES-1.31
+++ b/php/RELEASE-NOTES-1.31
@@ -1,3 +1,21 @@
+== MediaWiki 1.31.16 ==
+
+This is a security and maintenance release of the MediaWiki 1.31 branch.
+
+This is intended to be the final release of the MediaWiki 1.31 branch,
+and as such, 1.31 is now considered End of Life.
+
+=== Changes since MediaWiki 1.31.15 ===
+* (T283273) Make postgres IRC channel point to libera.chat.
+* (T289108) ExtensionProcessor: Remove loaderScripts from
+  extension.json schemas.
+* (T285515, CVE-2021-41798) SECURITY: XSS vulnerability in
+  Special:Search.
+* (T290379, CVE-2021-41799) SECURITY: ApiQueryBacklinks can cause a full
+  table scan.
+* (T284419, CVE-2021-41800) SECURITY: fix PoolCounter protection of
+  Special:Contributions.
+
 == MediaWiki 1.31.15 ==
 
 This is a security and maintenance release of the MediaWiki 1.31 branch.

--- a/php/RELEASE-NOTES-1.31
+++ b/php/RELEASE-NOTES-1.31
@@ -1,3 +1,19 @@
+== MediaWiki 1.31.15 ==
+
+This is a security and maintenance release of the MediaWiki 1.31 branch.
+
+=== Changes since MediaWiki 1.31.14 ===
+* (T270988) Fixup issues in SpecialChangeContentModel.php.
+* (T278026) rdbms: Add DB_PRIMARY to replace DB_MASTER.
+* (T276945) Define a batch size in maintenance/manageJobs.php.
+* (T276945) Implement JobQueueDB::getAllAbandonedJobs.
+* (T281549) WebInstaller: Don't show the announce-l subscribe
+  checkbox temporarily.
+* (T283247) Freenode -> Libera per wikimedia moving from
+  freenode to libera.
+* (T280226, CVE-2021-35197) SECURITY: Prevent blocked users from
+  purging pages.
+
 == MediaWiki 1.31.14 ==
 
 This is a maintenance release of the MediaWiki 1.31 branch.
@@ -829,4 +845,4 @@ It's highly recommended that you sign up for one of these lists if you're
 going to run a public MediaWiki, so you can be notified of security fixes.
 
 == IRC help ==
-There's usually someone online in #mediawiki on irc.freenode.net.
+There's usually someone online in #mediawiki on irc.libera.chat.

--- a/php/composer.json
+++ b/php/composer.json
@@ -13,7 +13,7 @@
 	"license": "GPL-2.0-or-later",
 	"support": {
 		"issues": "https://bugs.mediawiki.org/",
-		"irc": "irc://irc.freenode.net/mediawiki",
+		"irc": "irc://irc.libera.chat/mediawiki",
 		"wiki": "https://www.mediawiki.org/"
 	},
 	"require": {

--- a/php/composer.json.orig
+++ b/php/composer.json.orig
@@ -106,6 +106,10 @@
 		"test": [
 			"composer lint",
 			"composer phpcs"
+		],
+		"test-some": [
+			"composer lint",
+			"composer phpcs"
 		]
 	},
 	"config": {

--- a/php/extensions/CategoryTree/composer.json
+++ b/php/extensions/CategoryTree/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/Cite/composer.json
+++ b/php/extensions/Cite/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/CiteThisPage/composer.json
+++ b/php/extensions/CiteThisPage/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/CodeEditor/composer.json
+++ b/php/extensions/CodeEditor/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/ConfirmEdit/composer.json
+++ b/php/extensions/ConfirmEdit/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",
 		"php-parallel-lint/php-parallel-lint": "1.0.0"

--- a/php/extensions/Gadgets/composer.json
+++ b/php/extensions/Gadgets/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/ImageMap/composer.json
+++ b/php/extensions/ImageMap/composer.json
@@ -14,7 +14,7 @@
 		"composer/installers": "1.*,>=1.0.1"
 	},
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/InputBox/composer.json
+++ b/php/extensions/InputBox/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/Interwiki/composer.json
+++ b/php/extensions/Interwiki/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/LocalisationUpdate/composer.json
+++ b/php/extensions/LocalisationUpdate/composer.json
@@ -32,7 +32,7 @@
 		"wiki": "https://www.mediawiki.org/wiki/Extension:LocalisationUpdate"
 	},
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/LocalisationUpdate/composer.json
+++ b/php/extensions/LocalisationUpdate/composer.json
@@ -27,7 +27,7 @@
 	],
 	"support": {
 		"issues": "https://phabricator.wikimedia.org/",
-		"irc": "irc://irc.freenode.net/mediawiki",
+		"irc": "irc://irc.libera.chat/mediawiki",
 		"forum": "https://www.mediawiki.org/wiki/Extension_talk:LocalisationUpdate",
 		"wiki": "https://www.mediawiki.org/wiki/Extension:LocalisationUpdate"
 	},

--- a/php/extensions/MultimediaViewer/composer.json
+++ b/php/extensions/MultimediaViewer/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/Nuke/composer.json
+++ b/php/extensions/Nuke/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/OATHAuth/composer.json
+++ b/php/extensions/OATHAuth/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/OATHAuth/extension.json
+++ b/php/extensions/OATHAuth/extension.json
@@ -69,11 +69,19 @@
 				"jquery.qrcode.js",
 				"qrcode.js",
 				"ext.oath.showqrcode.js"
+			],
+			"targets": [
+				"desktop",
+				"mobile"
 			]
 		},
 		"ext.oath.showqrcode.styles": {
 			"styles": [
 				"ext.oath.showqrcode.styles.css"
+			],
+			"targets": [
+				"desktop",
+				"mobile"
 			]
 		}
 	},

--- a/php/extensions/ParserFunctions/composer.json
+++ b/php/extensions/ParserFunctions/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/PdfHandler/composer.json
+++ b/php/extensions/PdfHandler/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/Poem/composer.json
+++ b/php/extensions/Poem/composer.json
@@ -3,7 +3,7 @@
 		"php": ">=5.5.9"
 	},
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/Renameuser/composer.json
+++ b/php/extensions/Renameuser/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/ReplaceText/composer.json
+++ b/php/extensions/ReplaceText/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/ReplaceText/extension.json
+++ b/php/extensions/ReplaceText/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Replace Text",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"author": [
 		"Yaron Koren",
 		"Niklas Laxström",

--- a/php/extensions/ReplaceText/src/ReplaceTextJob.php
+++ b/php/extensions/ReplaceText/src/ReplaceTextJob.php
@@ -41,6 +41,14 @@ class ReplaceTextJob extends Job {
 	 * @return bool success
 	 */
 	function run() {
+		// T279090
+		$current_user = User::newFromId( $this->params['user_id'] );
+		if ( !$this->title->userCan( 'replacetext', $current_user ) ) {
+			$this->error = 'replacetext: permission no longer valid';
+			// T279090#6978214
+			return true;
+		}
+
 		if ( isset( $this->params['session'] ) ) {
 			$callback = RequestContext::importScopedSession( $this->params['session'] );
 			$this->addTeardownCallback( function () use ( &$callback ) {

--- a/php/extensions/SpamBlacklist/composer.json
+++ b/php/extensions/SpamBlacklist/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/SyntaxHighlight_GeSHi/composer.json
+++ b/php/extensions/SyntaxHighlight_GeSHi/composer.json
@@ -2,7 +2,7 @@
 	"name": "mediawiki/syntax-highlight",
 	"description": "Syntax highlighting extension for MediaWiki",
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/TitleBlacklist/composer.json
+++ b/php/extensions/TitleBlacklist/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/extensions/WikiEditor/composer.json
+++ b/php/extensions/WikiEditor/composer.json
@@ -1,7 +1,7 @@
 {
 	"license": "GPL-2.0-or-later",
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/mediawiki-phan-config": "0.2.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",

--- a/php/includes/Defines.php
+++ b/php/includes/Defines.php
@@ -37,7 +37,7 @@ use Wikimedia\Rdbms\IDatabase;
  *
  * @since 1.31.7
  */
-define( 'MW_VERSION', '1.31.15' );
+define( 'MW_VERSION', '1.31.16' );
 
 # Obsolete aliases
 /**

--- a/php/includes/Defines.php
+++ b/php/includes/Defines.php
@@ -37,7 +37,7 @@ use Wikimedia\Rdbms\IDatabase;
  *
  * @since 1.31.7
  */
-define( 'MW_VERSION', '1.31.14' );
+define( 'MW_VERSION', '1.31.15' );
 
 # Obsolete aliases
 /**

--- a/php/includes/actions/PurgeAction.php
+++ b/php/includes/actions/PurgeAction.php
@@ -33,10 +33,6 @@ class PurgeAction extends FormAction {
 		return 'purge';
 	}
 
-	public function requiresUnblock() {
-		return false;
-	}
-
 	public function getDescription() {
 		return '';
 	}

--- a/php/includes/api/ApiPurge.php
+++ b/php/includes/api/ApiPurge.php
@@ -32,6 +32,14 @@ class ApiPurge extends ApiBase {
 	 * Purges the cache of a page
 	 */
 	public function execute() {
+		$user = $this->getUser();
+
+		// Fail early if the user is blocked.
+		$block = $user->getBlock();
+		if ( $block ) {
+			$this->dieBlocked( $block );
+		}
+
 		$params = $this->extractRequestParams();
 
 		$continuationManager = new ApiContinuationManager( $this, [], [] );
@@ -43,7 +51,6 @@ class ApiPurge extends ApiBase {
 		$pageSet->execute();
 
 		$result = $pageSet->getInvalidTitlesAndRevisions();
-		$user = $this->getUser();
 
 		foreach ( $pageSet->getGoodTitles() as $title ) {
 			$r = [];

--- a/php/includes/api/ApiQueryBacklinks.php
+++ b/php/includes/api/ApiQueryBacklinks.php
@@ -206,7 +206,7 @@ class ApiQueryBacklinks extends ApiQueryGeneratorBase {
 	 */
 	private function runSecondQuery( $resultPageSet = null ) {
 		$db = $this->getDB();
-		$this->addTables( [ 'page', $this->bl_table ] );
+		$this->addTables( [ $this->bl_table, 'page' ] );
 		$this->addWhere( "{$this->bl_from}=page_id" );
 
 		if ( is_null( $resultPageSet ) ) {
@@ -280,6 +280,8 @@ class ApiQueryBacklinks extends ApiQueryGeneratorBase {
 		$orderBy[] = $this->bl_from . $sort;
 		$this->addOption( 'ORDER BY', $orderBy );
 		$this->addOption( 'USE INDEX', [ 'page' => 'PRIMARY' ] );
+		// T290379: Avoid MariaDB deciding to scan all of `page`.
+		$this->addOption( 'STRAIGHT_JOIN' );
 
 		$res = $this->select( __METHOD__ );
 		$count = 0;

--- a/php/includes/installer/WebInstallerName.php
+++ b/php/includes/installer/WebInstallerName.php
@@ -100,11 +100,12 @@ class WebInstallerName extends WebInstallerPage {
 				'label' => 'config-admin-email',
 				'help' => $this->parent->getHelpBox( 'config-admin-email-help' )
 			] ) .
-			$this->parent->getCheckBox( [
-				'var' => '_Subscribe',
-				'label' => 'config-subscribe',
-				'help' => $this->parent->getHelpBox( 'config-subscribe-help' )
-			] ) .
+			// (T281549) Don't show the subscribe checkbox temporarily whilst we fix auto-subscription.
+			// $this->parent->getCheckBox( [
+			// 	'var' => '_Subscribe',
+			// 	'label' => 'config-subscribe',
+			// 	'help' => $this->parent->getHelpBox( 'config-subscribe-help' )
+			// ] ) .
 			$this->parent->getCheckBox( [
 				'var' => 'wgPingback',
 				'label' => 'config-pingback',

--- a/php/includes/jobqueue/JobQueueDB.php
+++ b/php/includes/jobqueue/JobQueueDB.php
@@ -573,6 +573,18 @@ class JobQueueDB extends JobQueue {
 	}
 
 	/**
+	 * @see JobQueue::getAllAbandonedJobs()
+	 * @return Iterator
+	 */
+	public function getAllAbandonedJobs() {
+		return $this->getJobIterator( [
+			'job_cmd' => $this->getType(),
+			"job_token > ''",
+			"job_attempts >= " . intval( $this->maxTries )
+		] );
+	}
+
+	/**
 	 * @param array $conds Query conditions
 	 * @return Iterator
 	 */

--- a/php/includes/libs/rdbms/defines.php
+++ b/php/includes/libs/rdbms/defines.php
@@ -23,5 +23,8 @@ define( 'DBO_COMPRESS', IDatabase::DBO_COMPRESS );
  * Operation-based indexes
  */
 define( 'DB_REPLICA', ILoadBalancer::DB_REPLICA );
+/** @since 1.31.15 */
+define( 'DB_PRIMARY', ILoadBalancer::DB_PRIMARY );
+/** @deprecated since 1.31.15, Use DB_PRIMARY instead */
 define( 'DB_MASTER', ILoadBalancer::DB_MASTER );
 /**@}*/

--- a/php/includes/libs/rdbms/loadbalancer/ILoadBalancer.php
+++ b/php/includes/libs/rdbms/loadbalancer/ILoadBalancer.php
@@ -78,8 +78,17 @@ use InvalidArgumentException;
 interface ILoadBalancer {
 	/** @var int Request a replica DB connection */
 	const DB_REPLICA = -1;
-	/** @var int Request a master DB connection */
-	const DB_MASTER = -2;
+
+	/**
+	 * Request a primary, write-enabled DB connection
+	 * @since 1.31.15
+	 */
+	const DB_PRIMARY = -2;
+	/**
+	 * Request a primary, write-enabled DB connection
+	 * @deprecated since 1.31.15, Use DB_PRIMARY instead
+	 */
+	const DB_MASTER = self::DB_PRIMARY;
 
 	/** @var string Domain specifier when no specific database needs to be selected */
 	const DOMAIN_ANY = '';

--- a/php/includes/specials/SpecialChangeContentModel.php
+++ b/php/includes/specials/SpecialChangeContentModel.php
@@ -171,8 +171,8 @@ class SpecialChangeContentModel extends FormSpecialPage {
 		$user = $this->getUser();
 
 		$creationErrors = [];
-		if ( !$current->exists() ) {
-			$creationErrors = $this->title->getUserPermissionErrors( 'create', $user );
+		if ( !$this->title->exists() ) {
+			$creationErrors = $this->title->getUserPermissionsErrors( 'create', $user );
 		}
 
 		// Check permissions and make sure the user has permission to:

--- a/php/includes/specials/SpecialContributions.php
+++ b/php/includes/specials/SpecialContributions.php
@@ -235,8 +235,6 @@ class SpecialContributions extends IncludableSpecialPage {
 				$limits = $this->getConfig()->get( 'RangeContributionsCIDRLimit' );
 				$limit = $limits[ IP::isIPv4( $target ) ? 'IPv4' : 'IPv6' ];
 				$out->addWikiMsg( 'sp-contributions-outofrange', $limit );
-			} elseif ( !$pager->getNumRows() ) {
-				$out->addWikiMsg( 'nocontribs', $target );
 			} else {
 				// @todo We just want a wiki ID here, not a "DB domain", but
 				// current status of MediaWiki conflates the two. See T235955.
@@ -247,21 +245,24 @@ class SpecialContributions extends IncludableSpecialPage {
 					$poolKey .= 'u:' . $this->getUser()->getId();
 				}
 				$work = new PoolCounterWorkViaCallback( 'SpecialContributions', $poolKey, [
-					'doWork' => function () use ( $pager, $out ) {
-				# Show a message about replica DB lag, if applicable
-				$lb = MediaWikiServices::getInstance()->getDBLoadBalancer();
-				$lag = $lb->safeGetLag( $pager->getDatabase() );
-				if ( $lag > 0 ) {
-					$out->showLagWarning( $lag );
-				}
+					'doWork' => function () use ( $pager, $out, $target ) {
+						if ( !$pager->getNumRows() ) {
+							$out->addWikiMsg( 'nocontribs', $target );
+						} else {
+							# Show a message about replica DB lag, if applicable
+							$lag = $pager->getDatabase()->getSessionLagStatus()['lag'];
+							if ( $lag > 0 ) {
+								$out->showLagWarning( $lag );
+							}
 
-				$output = $pager->getBody();
-				if ( !$this->including() ) {
-					$output = '<p>' . $pager->getNavigationBar() . '</p>' .
-						$output .
-						'<p>' . $pager->getNavigationBar() . '</p>';
-				}
-				$out->addHTML( $output );
+							$output = $pager->getBody();
+							if ( !$this->including() ) {
+								$output = $pager->getNavigationBar() .
+									$output .
+									$pager->getNavigationBar();
+							}
+							$out->addHTML( $output );
+						}
 					},
 					'error' => function () use ( $out ) {
 						$msg = $this->getUser()->isAnon()

--- a/php/includes/widget/search/FullSearchResultWidget.php
+++ b/php/includes/widget/search/FullSearchResultWidget.php
@@ -54,9 +54,11 @@ class FullSearchResultWidget implements SearchResultWidget {
 		$redirect = $this->generateRedirectHtml( $result );
 		$section = $this->generateSectionHtml( $result );
 		$category = $this->generateCategoryHtml( $result );
-		$date = $this->specialPage->getLanguage()->userTimeAndDate(
-			$result->getTimestamp(),
-			$this->specialPage->getUser()
+		$date = htmlspecialchars(
+			$this->specialPage->getLanguage()->userTimeAndDate(
+				$result->getTimestamp(),
+				$this->specialPage->getUser()
+			)
 		);
 		list( $file, $desc, $thumb ) = $this->generateFileHtml( $result );
 		$snippet = $result->getTextSnippet( $terms );

--- a/php/maintenance/manageJobs.php
+++ b/php/maintenance/manageJobs.php
@@ -34,6 +34,7 @@ class ManageJobs extends Maintenance {
 		$this->addDescription( 'Perform administrative tasks on a job queue' );
 		$this->addOption( 'type', 'Job type', true, true );
 		$this->addOption( 'action', 'Queue operation ("delete", "repush-abandoned")', true, true );
+		$this->setBatchSize( 100 );
 	}
 
 	public function execute() {

--- a/php/skins/MonoBook/composer.json
+++ b/php/skins/MonoBook/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",
 		"php-parallel-lint/php-parallel-lint": "1.0.0"

--- a/php/skins/Timeless/composer.json
+++ b/php/skins/Timeless/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",
 		"php-parallel-lint/php-parallel-lint": "1.0.0"

--- a/php/skins/Vector/composer.json
+++ b/php/skins/Vector/composer.json
@@ -34,7 +34,7 @@
 		"installer-name": "Vector"
 	},
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "19.1.0",
+		"mediawiki/mediawiki-codesniffer": "19.4.0",
 		"mediawiki/minus-x": "0.3.1",
 		"php-parallel-lint/php-console-highlighter": "0.3.2",
 		"php-parallel-lint/php-parallel-lint": "1.0.0"

--- a/php/tests/phpunit/data/composer/composer.json
+++ b/php/tests/phpunit/data/composer/composer.json
@@ -12,7 +12,7 @@
 	"license": "GPL-2.0-only",
 	"support": {
 		"issues": "https://bugzilla.wikimedia.org/",
-		"irc": "irc://irc.freenode.net/mediawiki",
+		"irc": "irc://irc.libera.chat/mediawiki",
 		"wiki": "https://www.mediawiki.org/"
 	},
 	"require": {

--- a/php/tests/phpunit/data/composer/new-composer.json
+++ b/php/tests/phpunit/data/composer/new-composer.json
@@ -12,7 +12,7 @@
 	"license": "GPL-2.0-only",
 	"support": {
 		"issues": "https://bugzilla.wikimedia.org/",
-		"irc": "irc://irc.freenode.net/mediawiki",
+		"irc": "irc://irc.libera.chat/mediawiki",
 		"wiki": "https://www.mediawiki.org/"
 	},
 	"require": {


### PR DESCRIPTION
Bundling two patches, moving to final release (`1.31.16`).

Changes since `1.31.14`:
* (T283273) Make postgres IRC channel point to libera.chat.
* (T289108) ExtensionProcessor: Remove loaderScripts from extension.json schemas.
* (T285515, CVE-2021-41798) SECURITY: XSS vulnerability in Special:Search.
* (T290379, CVE-2021-41799) SECURITY: ApiQueryBacklinks can cause a full table scan.
* (T284419, CVE-2021-41800) SECURITY: fix PoolCounter protection of Special:Contributions.
* (T270988) Fixup issues in SpecialChangeContentModel.php.
* (T278026) rdbms: Add DB_PRIMARY to replace DB_MASTER.
* (T276945) Define a batch size in maintenance/manageJobs.php.
* (T276945) Implement JobQueueDB::getAllAbandonedJobs.
* (T281549) WebInstaller: Don't show the announce-l subscribe checkbox temporarily.
* (T283247) Freenode -> Libera per wikimedia moving from freenode to libera.
* (T280226, CVE-2021-35197) SECURITY: Prevent blocked users from purging pages.