### PR TITLE
Disable undo and restore functions

### DIFF
--- a/php/LocalSettings.php
+++ b/php/LocalSettings.php
@@ -353,3 +353,7 @@ $wgFooterIcons['poweredby']['openshift'] = [
 	"width" => "181",
 ];
 }
+
+# Disable actions
+$wgActions['mcrundo'] = false;
+$wgActions['mcrrestore'] = false;


### PR DESCRIPTION
Disable functions to prevent discovered security vulnerabilities:

* CVE-2021-44858: The "undo" feature (action=edit&undo=##&undoafter=###) allowed an attacker to view the contents of arbitrary revisions, regardless of whether they had permissions to do so. This was also found in the "mcrundo" and "mcrrestore" actions (action=mcrundo and action=mcrrestore).
* CVE-2021-45038: The "rollback" feature (action=rollback) could be passed a specially crafted parameter that allowed an attacker to view the contents of arbitrary pages, regardless of whether they had permissions to do so.
* CVE-2021-44857: The "mcrundo" and "mcrrestore" actions (action=mcrundo and action=mcrrestore) did not properly check for editing permissions, and allowed an attacker to take the content of any arbitrary revision and save it on any page of their choosing. This affects both public wikis and public pages on private wikis.

More info: https://www.mediawiki.org/wiki/2021-12_security_release/FAQ

Signed-off-by: Armando Neto <abiagion@redhat.com>

---
@mkosek I've left $wgWhitelist* vars out because FreeIPA wiki is public.